### PR TITLE
Add AUDIT #83 provenance comments across Phase 0 fix sites

### DIFF
--- a/actions/emailAction.js
+++ b/actions/emailAction.js
@@ -4,6 +4,9 @@ import { cookies } from "next/headers";
 
 export async function fetchInbox() {
   const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000"; // Define the base URL
+  // AUDIT #83: /api/email is now admin-guarded. A server-to-server fetch does not
+  // inherit the user's cookies automatically, so forward them — otherwise the
+  // admin's own inbox view would 401.
   const res = await fetch(`${baseUrl}/api/email`, {
     cache: "no-store",
     headers: { Cookie: cookies().toString() },
@@ -22,6 +25,7 @@ export async function fetchInbox() {
 
 export async function fetchUnseen() {
   const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000"; // Define the base URL
+  // AUDIT #83: forward the session cookie (see fetchInbox) — /api/email/count is admin-guarded.
   const res = await fetch(`${baseUrl}/api/email/count`, {
     cache: "no-store",
     headers: { Cookie: cookies().toString() },

--- a/actions/memberAction.js
+++ b/actions/memberAction.js
@@ -5,6 +5,11 @@ import connectDB from "@/lib/database";
 import { requireAdmin } from "@/lib/authGuard";
 import { z } from "zod";
 
+// AUDIT #83 (issue #82): every MUTATING action below (create/update/delete) is
+// gated by requireAdmin(), which derives the admin role from the server session.
+// Previously each took a `role` argument FROM THE CLIENT and checked
+// `if (role !== "admin")`, so a forged request passing role:"admin" bypassed
+// authorization. Read-only getters are intentionally left ungated.
 export async function getMembers() {
   try {
     await connectDB();

--- a/actions/userActions.js
+++ b/actions/userActions.js
@@ -5,6 +5,10 @@ import { requireAdmin } from "@/lib/authGuard";
 import { z } from "zod";
 import bcrypt from "bcrypt";
 
+// AUDIT #83 (issue #82): every action below is gated by requireAdmin(), which
+// derives the admin role from the server session. Previously each took a `role`
+// argument FROM THE CLIENT and checked `if (role !== "admin")`, so a forged
+// request passing role:"admin" bypassed authorization entirely.
 export const updateUser = async (formData, id) => {
 
 

--- a/actions/workAction.js
+++ b/actions/workAction.js
@@ -7,6 +7,11 @@ import { requireAdmin } from "@/lib/authGuard";
 import { z } from "zod";
 
 
+// AUDIT #83 (issue #82): every MUTATING action below (create/update/delete) is
+// gated by requireAdmin(), which derives the admin role from the server session.
+// Previously each took a `role` argument FROM THE CLIENT and checked
+// `if (role !== "admin")`, so a forged request passing role:"admin" bypassed
+// authorization. Read-only getters are intentionally left ungated.
 export async function getWorks() {
   try {
     await connectDB();

--- a/app/[locale]/(dashboard)/layout.jsx
+++ b/app/[locale]/(dashboard)/layout.jsx
@@ -13,6 +13,8 @@ export const metadata = {
 export default async function DashboardLayout({ children }) {
   // Single server-side enforcement point for the whole dashboard: role is
   // derived from the session, never trusted from the client.
+  // AUDIT #83 (issue #82): this layout was a passthrough — role was only checked
+  // on the (untrusted) client, so any authenticated user could reach the dashboard.
   const session = await getServerSession(authOptions);
   if (!session || session.user?.role !== "admin") {
     redirect("/login");

--- a/app/api/email/count/route.js
+++ b/app/api/email/count/route.js
@@ -4,6 +4,8 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 
 export async function GET(req) {
+  // AUDIT #83 (issue #82): the unread-count endpoint was world-readable — it
+  // connected to Gmail IMAP with no auth. Now admin-only.
   const session = await getServerSession(authOptions);
   if (!session || session.user?.role !== "admin") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/email/route.js
+++ b/app/api/email/route.js
@@ -8,6 +8,8 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 
 export async function POST(request) {
+  // AUDIT #83: the contact form is public by design — only GET (the inbox read)
+  // was locked down; POST stays unauthenticated intentionally.
   const { email, name, message } = await request.json();
 
   const transport = nodemailer.createTransport({
@@ -46,6 +48,8 @@ export async function POST(request) {
 }
 
 export async function GET(req) {
+  // AUDIT #83 (issue #82): the inbox was world-readable — this handler connected
+  // to Gmail IMAP with no auth check, so anyone could read the mailbox.
   const session = await getServerSession(authOptions);
   if (!session || session.user?.role !== "admin") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/user/route.js
+++ b/app/api/user/route.js
@@ -5,6 +5,9 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 
+// AUDIT #83 (issue #82): this route was previously unauthenticated and exported
+// as BOTH POST and GET, so anyone could create users. The GET export has been
+// removed; only an authenticated admin may POST here.
 export async function POST(req) {
   // Only an authenticated admin may create users. There is no public signup UI.
   const session = await getServerSession(authOptions);
@@ -19,6 +22,7 @@ export async function POST(req) {
     const hashedPassword = await bcrypt.hash(body.password, 10);
     // Create a new user with the hashed password. Role is never taken from the
     // request body — new users are always created as "user".
+    // AUDIT #83: was `role: res.role` (trusted the request body) → privilege escalation.
     const user = await User.create({
       userMail: body.email,
       userPassword: hashedPassword,
@@ -27,6 +31,8 @@ export async function POST(req) {
       role: "user",
     });
     // Respond with the created user, explicitly omitting the password hash.
+    // AUDIT #83: the omit destructured `password` (a field that does not exist)
+    // instead of `userPassword`, so the bcrypt hash leaked in the response.
     const { userPassword, ...userWithoutPassword } = user.toObject();
     return NextResponse.json(userWithoutPassword, { status: 201 });
   } catch (error) {

--- a/components/MemberDetails.jsx
+++ b/components/MemberDetails.jsx
@@ -26,6 +26,8 @@ export default function MemberDetails({ member }) {
   }
 
   const handleDelete = () => {
+    // AUDIT #83: UX hint only, NOT the security boundary — real authorization is
+    // enforced server-side in the action (requireAdmin). Kept for a friendly toast.
     if (data.user.role !== "admin") {
       toast({
         variant: "destructive",

--- a/components/WorkDetails.jsx
+++ b/components/WorkDetails.jsx
@@ -34,6 +34,8 @@ export default function MemberDetails({ work }) {
   }
   console.log(work);
   const handleDelete = () => {
+    // AUDIT #83: UX hint only, NOT the security boundary — real authorization is
+    // enforced server-side in the action (requireAdmin). Kept for a friendly toast.
     if (data.user.role !== "admin") {
       toast({
         variant: "destructive",

--- a/components/forms/EditMemberForm.jsx
+++ b/components/forms/EditMemberForm.jsx
@@ -54,6 +54,8 @@ export const EditMemberForm = ({ member, user }) => {
   });
 
   const onSubmit = async (values) => {
+    // AUDIT #83: UX hint only, NOT the security boundary — real authorization is
+    // enforced server-side in the action (requireAdmin). Kept for a friendly toast.
     if (user.role !== "admin") {
       toast({
         variant: "destructive",

--- a/components/forms/EditUserForm.jsx
+++ b/components/forms/EditUserForm.jsx
@@ -63,6 +63,8 @@ export const EditUserForm = ({ user }) => {
   }, []);
 
   const onSubmit = async (values) => {
+    // AUDIT #83: UX hint only, NOT the security boundary — real authorization is
+    // enforced server-side in the action (requireAdmin). Kept for a friendly toast.
     if (user.role !== "admin") {
       toast({
         variant: "destructive",

--- a/components/forms/EditUserPasswordForm.jsx
+++ b/components/forms/EditUserPasswordForm.jsx
@@ -46,6 +46,8 @@ export const EditUserPasswordForm = ({ user }) => {
   });
   const onSubmit = async (values) => {
     console.log(values);
+    // AUDIT #83: UX hint only, NOT the security boundary — real authorization is
+    // enforced server-side in the action (requireAdmin). Kept for a friendly toast.
     if (user.role !== "admin") {
       toast({
         variant: "destructive",

--- a/components/forms/EditWorkForm.jsx
+++ b/components/forms/EditWorkForm.jsx
@@ -54,6 +54,8 @@ export const EditWorkForm = ({ work, user }) => {
   });
 
   const onSubmit = async (values) => {
+    // AUDIT #83: UX hint only, NOT the security boundary — real authorization is
+    // enforced server-side in the action (requireAdmin). Kept for a friendly toast.
     if (user.role !== "admin") {
       toast({
         variant: "destructive",

--- a/components/forms/NewMemberForm.jsx
+++ b/components/forms/NewMemberForm.jsx
@@ -63,6 +63,8 @@ const NewMemberForm = () => {
     },
   });
   const onSubmit = async (values) => {
+    // AUDIT #83: UX hint only, NOT the security boundary — real authorization is
+    // enforced server-side in the action (requireAdmin). Kept for a friendly toast.
     if (data.user.role !== "admin") {
       toast({
         variant: "destructive",

--- a/components/forms/NewWorkForm.jsx
+++ b/components/forms/NewWorkForm.jsx
@@ -68,6 +68,8 @@ const NewWorkForm = () => {
   });
 
   async function newWork(formData) {
+    // AUDIT #83: UX hint only, NOT the security boundary — real authorization is
+    // enforced server-side in the action (requireAdmin). Kept for a friendly toast.
     if (data.user.role !== "admin") {
       toast({
         variant: "destructive",

--- a/lib/authGuard.js
+++ b/lib/authGuard.js
@@ -1,6 +1,11 @@
 // lib/authGuard.js
 // Server-side authorization boundary for mutating server actions.
 // Role is derived from the server session — never from client input.
+//
+// AUDIT #83 (issue #82): added to close a privilege-escalation hole. Mutating
+// actions previously trusted a `role` argument passed from the client and gated
+// on `if (role !== "admin")`, so a forged request with role:"admin" bypassed all
+// authorization. requireAdmin() replaces that with a server-session check.
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 


### PR DESCRIPTION
Annotates every Phase 0 fix site with a consistent, greppable `// AUDIT #83:` comment that states the issue/error that existed and points to the PR (#83) / issue (#82) that resolved it — so the security history is auditable from the code alone (`grep -rn "AUDIT #"`).

- **17 files, comment-only** (53 insertions, 0 deletions — no logic changed).
- **Server side:** `lib/authGuard`, the 3 action files, `/api/user`, both inbox routes, the dashboard layout, `emailAction` (cookie forwarding).
- **Client side:** the 8 forms / detail components — clarifying that the client-side role checks are UX hints, **not** the security boundary.

Part of #81. Style is easy to tweak — say if you'd like it terser or more verbose.