### PR TITLE
docs(conventions): minimal diffs + one issue per PR (CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ A 7-phase modernization is under way, tracked by epic **#81**. **`docs/migration
 - **Never commit to `main`.** Branch off the latest `origin/main` using the repo convention `<issue#>-<slug>` (e.g. `82-security-hotfix`).
 - **Atomic, conventional commits** — one logical change per commit (`feat(...)`, `fix(...)`, `refactor:` …). Rule of thumb: if the message needs the word "and", it is probably two commits.
 - **One PR per phase**, opened with `--base main`; the PR body closes its tracking issue (`Closes #N`).
+- **One PR = one issue.** Every PR must revolve around a single issue/concern — never bundle unrelated changes into one PR (this generalizes the per-phase rule above). Open a separate issue + PR for each distinct concern.
+- **Minimal, focused diffs.** Change only what the issue requires; keep edits surgical and additive. Do not churn, reformat, or refactor unrelated code in the same PR.
 - End commit messages with: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
 
 ### Verify empirically


### PR DESCRIPTION
Adds two working-convention rules to CLAUDE.md:

1. **One PR = one issue/concern** — never bundle unrelated changes (generalizes one-PR-per-phase).
2. **Minimal, focused diffs** — change only what the issue requires; no churn or unrelated refactors.

Docs-only. Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)