### PR TITLE
docs: refresh CLAUDE.md env section for lib/env.ts (Phase 2 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Guidance for Claude Code (and any AI agent) working in this repository. Read thi
 **team-random** is a Next.js 14 (App Router) portfolio / agency site: a public marketing site plus an admin-only dashboard for managing works, team members, and a contact inbox. Built May 2024; being modernized to 2026 standards (see **Modernization** below).
 
 - **Framework:** Next.js 14 (App Router), React 18. All JavaScript (`.jsx`) today; migrating to TypeScript in Phase 3.
-- **Data:** MongoDB via Mongoose. Models in `models/`: `user`, `member`, `work`.
+- **Data:** MongoDB via Mongoose (cached connection in `lib/database.ts`). Models in `models/`: `user`, `member`, `work`.
 - **Auth:** Better Auth (email/password over MongoDB; existing bcrypt hashes preserved from the legacy next-auth data). Role-based (`admin` / `user`) via the admin plugin. **Authorization is derived from the server session** — `lib/authGuard.js` → `requireAdmin()` and `auth.api.getSession()` (`lib/auth.ts`); never trust a client-supplied role. The dashboard is admin-only, enforced server-side in its layout. (Replaced next-auth v4 in Phase 1 — PR #88.)
 - **Uploads:** EdgeStore (`lib/edgestore.js`). **Email:** Gmail SMTP for the contact form + IMAP for the inbox, via `nodemailer` / `imapflow`.
 - **i18n:** next-intl (`config.ts`, `navigation.js`, `i18n.js`, `messages/en.json` + `tr.json`) — most strings are still hardcoded (addressed in Phase 6).
@@ -25,7 +25,7 @@ Guidance for Claude Code (and any AI agent) working in this repository. Read thi
 - `npm run lint` — ESLint. NOTE: the config is currently broken (`Failed to load config "next/babel"`); Phase 5 replaces it with flat config.
 
 ### Environment (nothing committed; `.env*.local` is gitignored)
-`MONGO_URI`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `APP_EMAIL`, `APP_PASSWORD`, `EDGE_STORE_ACCESS_KEY`, `EDGE_STORE_SECRET_KEY`, `NEXT_PUBLIC_API_BASE_URL`.
+All env vars are validated once at boot in **`lib/env.ts`** (Zod, fail-fast, server-only) — import `env` from there, never read `process.env` directly. **Required:** `MONGO_URI`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `APP_EMAIL`, `APP_PASSWORD`, `EDGE_STORE_ACCESS_KEY`, `EDGE_STORE_SECRET_KEY`. **Optional (defaults in `lib/env.ts`):** `NEXT_PUBLIC_API_BASE_URL` (`http://localhost:3000`), `IMAP_HOST` (`imap.gmail.com`), `IMAP_PORT` (`993`), `SALT_ROUNDS` (`10`).
 
 ## Modernization (the current effort)
 


### PR DESCRIPTION
Follow-up to Phase 2 (#96 / PR #97): brings `CLAUDE.md` in line with the new env plumbing.

## What
- **Environment section** now points at **`lib/env.ts`** as the validated, fail-fast, server-only source of truth ("import `env`, never read `process.env` directly"), and splits the flat var list into **required** vs **optional-with-defaults** (`NEXT_PUBLIC_API_BASE_URL`, `IMAP_HOST`, `IMAP_PORT`, `SALT_ROUNDS`).
- **Data line** notes the cached connection in **`lib/database.ts`**.

Docs-only; no code change. Branched off `main`, so it's independent of PR #97 (Phase 2 code) and PR #95 (conventions) — they touch different sections of `CLAUDE.md` and won't conflict.

Closes #98