### PR TITLE
feat: enable Vercel Web Analytics

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { EdgeStoreProvider } from "@/lib/edgestore";
 import { inter } from "../fonts";
 import Footer from "@/components/Footer";
+import { Analytics } from "@vercel/analytics/next";
 
 export const metadata = {
   title: "Team Random",
@@ -42,6 +43,7 @@ export default function LocaleLayout({
           </ThemeProvider>
         </EdgeStoreProvider>
         <Toaster />
+        <Analytics />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@tsparticles/engine": "^3.3.0",
         "@tsparticles/react": "^3.0.0",
         "@tsparticles/slim": "^3.3.0",
+        "@vercel/analytics": "^2.0.1",
         "base-64": "^1.0.0",
         "bcrypt": "^5.1.1",
         "better-auth": "^1.6.23",
@@ -4303,6 +4304,48 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tsparticles/engine": "^3.3.0",
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.3.0",
+    "@vercel/analytics": "^2.0.1",
     "base-64": "^1.0.0",
     "bcrypt": "^5.1.1",
     "better-auth": "^1.6.23",


### PR DESCRIPTION
Enables [Vercel Web Analytics](https://vercel.com/docs/analytics) for the site.

## Changes
- Add `@vercel/analytics` (v2.0.1) dependency.
- Mount `<Analytics />` (App Router `/next` entrypoint) in `app/[locale]/layout.tsx`, inside `<body>` alongside `<Toaster />`, so it renders on every route — public marketing site and admin dashboard alike.

## Not included
- **Speed Insights** — intentionally skipped. It's limited to a single project on our plan, and this lightweight site isn't where we want to spend it.

## Verification
- `npx tsc --noEmit` — clean.
- Analytics is a no-op outside the Vercel environment; page views begin recording once the **Analytics** tab is enabled in the Vercel dashboard and a production deploy goes out.

## Post-merge (dashboard, no code)
Vercel dashboard → project → **Analytics** tab → **Enable**. No env vars or keys required.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)