### PR TITLE
docs: add .env.example enumerating required env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# ------------------------------------------------------------------------------
+# team-random — environment variable template
+#
+# Copy this file to `.env.local` (gitignored) and fill in the real values, then
+# mirror the same set into the Vercel project (Production + Preview).
+# Every variable below is validated once at boot by `lib/env.ts` (Zod, fail-fast),
+# so a missing/malformed value fails the build with a single readable error.
+#
+# Secrets are left blank on purpose — never commit real values to this file.
+# ------------------------------------------------------------------------------
+
+# --- Required ---------------------------------------------------------------
+
+# MongoDB connection string (MongoDB Atlas → Connect → Drivers).
+MONGO_URI=
+
+# Better Auth signing secret. Generate a fresh one with: openssl rand -base64 32
+BETTER_AUTH_SECRET=
+
+# Canonical app URL used by Better Auth.
+#   Local: http://localhost:3000   •   Production: https://www.teamrandom.dev
+BETTER_AUTH_URL=http://localhost:3000
+
+# Gmail account that sends the contact form and owns the IMAP inbox.
+APP_EMAIL=
+# Gmail **App Password** (Google Account → Security → App Passwords) — NOT the
+# normal login password.
+APP_PASSWORD=
+
+# EdgeStore keys (EdgeStore dashboard → your project → API keys).
+EDGE_STORE_ACCESS_KEY=
+EDGE_STORE_SECRET_KEY=
+
+# --- Optional (defaults reproduced from lib/env.ts) -------------------------
+
+# Public base URL for the contact API. Inlined into the client bundle, so set it
+# to the production URL when deploying.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
+
+# IMAP inbox connection (Gmail defaults).
+IMAP_HOST=imap.gmail.com
+IMAP_PORT=993
+
+# bcrypt cost factor used when hashing new passwords.
+SALT_ROUNDS=10


### PR DESCRIPTION
Adds a root `.env.example` template so the variables a build/deploy needs are documented in-repo (they validate through `lib/env.ts`).

## Contents
- **7 required** (`MONGO_URI`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `APP_EMAIL`, `APP_PASSWORD`, `EDGE_STORE_ACCESS_KEY`, `EDGE_STORE_SECRET_KEY`) — secrets left blank.
- **4 optional** with their `lib/env.ts` defaults reproduced — including the **IMAP** settings (`IMAP_HOST=imap.gmail.com`, `IMAP_PORT=993`).
- Comments point each secret at its source (Atlas, EdgeStore, Gmail App Passwords) and note the prod vs local URL split.

No secrets committed; `.env.example` is not gitignored, real `.env*.local` still are.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)