### PR TITLE
[hotfix] fix(tailwind): scan .ts/.tsx sources so utilities are generated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Guidance for Claude Code (and any AI agent) working in this repository. Read thi
 - **Auth:** Better Auth (email/password over MongoDB; existing bcrypt hashes preserved from the legacy next-auth data). Role-based (`admin` / `user`) via the admin plugin. **Authorization is derived from the server session** — `lib/authGuard.ts` → `requireAdmin()` and `auth.api.getSession()` (`lib/auth.ts`); never trust a client-supplied role. The dashboard is admin-only, enforced server-side in its layout. (Replaced next-auth v4 in Phase 1 — PR #88.)
 - **Uploads:** EdgeStore (`lib/edgestore.ts`). **Email:** Gmail SMTP for the contact form + IMAP for the inbox, via `nodemailer` / `imapflow`.
 - **i18n:** next-intl (`config.ts`, `navigation.ts`, `i18n.ts`, `messages/en.json` + `messages/tr.json`) — most strings are still hardcoded (addressed in Phase 6).
-- **State:** zustand + jotai (to be consolidated in Phase 6). **UI:** Tailwind + shadcn/ui (`components/ui/`) + Radix + Framer Motion.
+- **State:** zustand + jotai (to be consolidated in Phase 6). **UI:** Tailwind + shadcn/ui (`components/ui/`) + Radix + Framer Motion. **Gotcha:** keep Tailwind's `content` globs in `tailwind.config.js` at `.{js,ts,jsx,tsx,mdx}` — the Phase 3 TS migration left them at `.{js,jsx}`, so Tailwind scanned none of the `.tsx` sources, generated no utilities, and the whole site rendered as unstyled HTML on a bare background (regression fixed in PR #120).
 
 ### Layout
 - `actions/` — server actions (`"use server"`): `memberAction`, `workAction`, `userActions`, `emailAction`.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,10 +9,10 @@ const {
 module.exports = {
   darkMode: ["class"],
   content: [
-    "./pages/**/*.{js,jsx}",
-    "./components/**/*.{js,jsx}",
-    "./app/**/*.{js,jsx}",
-    "./src/**/*.{js,jsx}",
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   prefix: "",
   theme: {


### PR DESCRIPTION
## Hotfix — restores the entire site's styling

Closes #119.

### Problem
After the Phase 3 TypeScript migration, `tailwind.config.js` `content` globs still only matched `.{js,jsx}`. All app sources are now `.tsx`/`.ts`, so Tailwind scanned no real files, generated almost no utilities, and the site rendered as unstyled stacked HTML on the theme's bare green background.

### Change
Add `ts,tsx,mdx` to every `content` glob (standard shadcn/Next.js set). One file, four lines.

```diff
-    "./app/**/*.{js,jsx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
```
(and the same for `pages`, `components`, `src`)

### Verification (empirical)
Compiled `app/globals.css` against the config, before vs after the change:

| | CSS output | layout utilities (`.flex` `.grid` `.min-h-screen` `.gap-4` …) |
|---|---|---|
| before (`.{js,jsx}`) | 912 lines / 19.5 KB | **none generated** |
| after (`+ts,tsx,mdx`) | 4546 lines / 89.6 KB | **all present** |

The full utility layer (4.5× more CSS) is restored.

> Note: a live browser screenshot wasn't possible in the fix environment (dev server needs `MONGO_URI` / Better Auth / EdgeStore env). Proof is the Tailwind compile above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)