### PR TITLE
fix(theme): make --foreground a valid HSL triplet

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,7 +46,10 @@
     /* --gradient: #0f2027; */
     --background: 110, 59%, 68%;
     /* --foreground: 110, 4.4%, 0.44%; */
-    --foreground: #0331BA;
+    /* HSL triplet form so `hsl(var(--foreground))` (tailwind.config.js) is valid.
+       A bare hex here produced `hsl(#0331BA)`, which is invalid CSS and dropped,
+       leaving body text at the browser default. 225,97%,37% == #0331BA. */
+    --foreground: 225, 97%, 37%;
     --muted: 110, 4.4%, 91.1%;
     --muted-foreground: 110, 2.2%, 41.1%;
     --popover: 110, 54.8%, 91.1%;


### PR DESCRIPTION
Closes #121.

### Problem
`app/globals.css` set `--foreground: #0331BA` (a hex), but `tailwind.config.js` consumes it as `hsl(var(--foreground))`. That yields `color: hsl(#0331BA)` — invalid CSS (`hsl()` takes a hue + percentages, never a hex) — so the declaration is dropped and body text falls back to the browser default. Every other variable in the block already uses the comma-triplet form (e.g. `--background: 110, 59%, 68%`, which is why the green background renders), making `--foreground` the lone outlier.

### Change (1 line + provenance comment)
```diff
-    --foreground: #0331BA;
+    --foreground: 225, 97%, 37%;   /* == #0331BA */
```
Now identical in form to the working `--background` sibling directly above it.

### Verification
- The new value uses the exact comma-triplet syntax as ~20 sibling vars in the same block that already render correctly (the live green `--background` is proof the form works).
- Per CSS spec, `hsl(<hex>)` is invalid and dropped; `hsl(225, 97%, 37%)` is valid. I couldn't run a headless browser / semantic CSS validator in this environment, so this is spec-level + format-consistency verification rather than a rendered-pixel check — stating that honestly.

### Design note
The commented line above (`/* --foreground: 110, 4.4%, 0.44%; */`) suggests the original text color was near-black. This PR preserves the more recent **blue** intent (`#0331BA`) while making it valid. If dark-blue body text on the green background isn't desired, that near-black triplet is a one-line alternative — happy to switch.

Separate from #119/#120 (the Tailwind content-glob outage); surfaced as its own issue+PR per the repo's one-PR-one-issue rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)