### PR TITLE
fix(contact): surface failed sends + handle inert email window (#127)

### DIFF
--- a/app/api/email/route.ts
+++ b/app/api/email/route.ts
@@ -12,6 +12,22 @@ export async function POST(request: Request) {
   // was locked down; POST stays unauthenticated intentionally.
   const { email, name, message } = await request.json();
 
+  // Graceful inert-state handling (issue #127, precursor to #116): APP_EMAIL /
+  // APP_PASSWORD default to "" while the Gmail integration is being retired (see
+  // lib/env.ts). With no credentials, nodemailer would throw a confusing auth
+  // error on EVERY send. Short-circuit before that and answer 503 so the client
+  // can show an honest "temporarily unavailable" message instead of a generic
+  // failure toast. Remove this branch once #116 restores a real send path.
+  if (!env.APP_EMAIL || !env.APP_PASSWORD) {
+    console.warn(
+      "[/api/email] Contact send skipped: APP_EMAIL/APP_PASSWORD are unset (inert Gmail window, tracked by #116).",
+    );
+    return NextResponse.json(
+      { error: "email-not-configured" },
+      { status: 503 },
+    );
+  }
+
   const transport = nodemailer.createTransport({
     service: "gmail",
     auth: {

--- a/lib/sendMail.ts
+++ b/lib/sendMail.ts
@@ -14,10 +14,35 @@ export async function sendEmail(data: ContactFormData): Promise<ActionState> {
             method: 'POST',
             body: JSON.stringify(data),
         });
-        const responseData = await response.json();
+        // /api/email answers 200 `{ message }` on a successful send and
+        // 500 `{ error }` when nodemailer rejects. Honour that status so a
+        // failed send surfaces the destructive branch in ContactForm instead
+        // of the previous behaviour, which returned `{ message }` regardless
+        // and always showed a success-ish toast (issue #127).
+        if (!response.ok) {
+            // 503 = the Gmail integration is inert (APP_EMAIL/APP_PASSWORD unset;
+            // see app/api/email/route.ts and issue #116). Give the visitor an
+            // honest "temporarily unavailable" message rather than a generic error.
+            if (response.status === 503) {
+                return {
+                    error: "email-not-configured",
+                    message:
+                        "The contact form is temporarily unavailable. Please email us directly.",
+                };
+            }
+            return {
+                error: "send-failed",
+                message: "Something went wrong !",
+            };
+        }
         return { message: "Your message sent successfully !" }
     } catch (err) {
+        // Network / unexpected failure (fetch threw): also surface the error
+        // branch so the user sees a destructive toast rather than a false success.
         console.log(err);
-        return { message: "Something went wrong !" }
+        return {
+            error: "send-failed",
+            message: "Something went wrong !",
+        };
     }
 }


### PR DESCRIPTION
## Problem
`lib/sendMail.ts` (`sendEmail`) returned `{ message }` on **every** path — success, HTTP failure, and its `catch` — ignoring `response.ok`. That left `ContactForm`'s `if (result.error)` branch dead, so a **failed send still showed a non-destructive, success-ish toast** (issue #127).

## Fix
- **`sendEmail` now honours the status `/api/email` already sets:** `200 { message }` → success; `!response.ok` or a thrown `fetch` → `{ error, message }`, so `ContactForm`'s destructive branch fires. No change was needed in `ContactForm.tsx` — it already reads `result.error` / `result.message`.
- **Graceful inert-state handling (the issue's caveat):** `APP_EMAIL`/`APP_PASSWORD` default to `""` while the Gmail integration is retired (`lib/env.ts`, #116). Without creds, nodemailer throws a confusing auth error on every send — which, paired with the fix above, would surface a generic failure toast to every visitor during the inert window. The route now detects the unset creds up front and answers `503 { error: "email-not-configured" }`; `sendEmail` maps 503 to an honest **"The contact form is temporarily unavailable. Please email us directly."** message. Both the short-circuit and the mapping are tagged for removal once #116 restores a real send path.

## Verification
- `npm run typecheck` — passes clean.
- Exercised `sendEmail` end-to-end against stubbed `/api/email` responses:

  | response | result |
  | --- | --- |
  | `200 { message }` | `{ message: "Your message sent successfully !" }` → success toast |
  | `500 { error }` | `{ error: "send-failed", message: "Something went wrong !" }` → destructive toast |
  | `503 { error: "email-not-configured" }` | `{ error: "email-not-configured", message: "…temporarily unavailable…" }` → destructive toast |
  | `fetch` throws | `{ error: "send-failed", message: "Something went wrong !" }` → destructive toast |

## Acceptance
- [x] Failed send returns `{ error }` and shows a destructive toast.
- [x] Inert-email window handled gracefully (honest 503 message; full removal deferred to #116).

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
