### PR TITLE
fix(edgestore): gate uploads and deletes behind an admin session

### DIFF
--- a/app/api/edgestore/[...edgestore]/route.ts
+++ b/app/api/edgestore/[...edgestore]/route.ts
@@ -1,17 +1,73 @@
 import { initEdgeStore } from '@edgestore/server';
-import { createEdgeStoreNextHandler } from '@edgestore/server/adapters/next/app';
+import {
+  createEdgeStoreNextHandler,
+  type CreateContextOptions,
+} from '@edgestore/server/adapters/next/app';
+import { auth } from '@/lib/auth';
 
-const es = initEdgeStore.create();
+// AUDIT #125 (issue #125): close an unauthenticated-upload hole. This handler
+// hands out the signed URLs the client uses to write to the bucket, and it
+// previously mounted `es.fileBucket()` with NO context and NO access control —
+// so any caller (logged-out, or a non-admin logged-in user) who hit this route
+// directly could obtain a signed URL and upload/delete files in the bucket.
+//
+// The dashboard forms' client-side role check (e.g. NewWorkForm.tsx) is a UX
+// hint only, and the `requireAdmin()` gate on the follow-up server action
+// (createWork/createMember/…) only ever protected the DB write — by the time it
+// ran, the file was already in the bucket. The upload itself was never guarded.
+//
+// The fix derives the caller's role from the Better Auth server session (never
+// from client input — the same invariant lib/authGuard.ts enforces) and rejects
+// non-admins in the bucket's beforeUpload/beforeDelete hooks, before any signed
+// URL is issued. Both hooks are gated: the forms only ever call `.upload(...)`
+// today, but the same handler also exposes `.delete(...)`, so leaving delete
+// open would be the same hole by another name.
 
 /**
- * This is the main router for the Edge Store buckets.
+ * Per-request context for the EdgeStore handler. `userRole` comes from the
+ * Better Auth server session and is the only thing the access-control hooks
+ * below key off.
+ *
+ * IMPORTANT — this MUST NOT throw for anonymous callers. The <EdgeStoreProvider>
+ * is mounted in app/[locale]/layout.tsx, i.e. on every page of the PUBLIC site,
+ * and its client init request flows through this same handler (and therefore
+ * this createContext). Throwing here would break the provider — and thus every
+ * public page — for logged-out visitors. So we resolve the role leniently
+ * (null when there is no session) and let the per-bucket hooks do the rejecting.
+ */
+type Context = {
+  userId: string | null;
+  userRole: string | null;
+};
+
+async function createContext({ req }: CreateContextOptions): Promise<Context> {
+  const session = await auth.api.getSession({ headers: req.headers });
+  return {
+    userId: session?.user?.id ?? null,
+    userRole: session?.user?.role ?? null,
+  };
+}
+
+const es = initEdgeStore.context<Context>().create();
+
+/**
+ * The main router for the Edge Store buckets.
+ *
+ * `beforeUpload` / `beforeDelete` run server-side while EdgeStore decides whether
+ * to grant a signed URL. Returning `false` denies the operation *before* any URL
+ * is handed out, so a non-admin never touches the bucket. This is the real
+ * security boundary for uploads and deletes (issue #125).
  */
 const edgeStoreRouter = es.router({
-  publicFiles: es.fileBucket(),
+  publicFiles: es
+    .fileBucket()
+    .beforeUpload(({ ctx }) => ctx.userRole === 'admin')
+    .beforeDelete(({ ctx }) => ctx.userRole === 'admin'),
 });
 
 const handler = createEdgeStoreNextHandler({
   router: edgeStoreRouter,
+  createContext,
 });
 
 export { handler as GET, handler as POST };
@@ -22,4 +78,3 @@ export { handler as GET, handler as POST };
 // type-checked. Only the *type* is imported on the client, so no server code
 // crosses the boundary.
 export type EdgeStoreRouter = typeof edgeStoreRouter;
-


### PR DESCRIPTION
## Problem
`app/api/edgestore/[...edgestore]/route.ts` mounted `es.fileBucket()` with **no context and no access control**. This handler hands out the signed URLs the client uses to write to the bucket, so any caller — logged-out, or a non-admin logged-in user — who hit the route directly could obtain a signed URL and **upload/delete files in the bucket**.

The dashboard forms' client-side role check is a UX hint only, and `requireAdmin()` guarded only the follow-up DB write (`createWork`/`createMember`/…) — by the time it ran, the file was already in the bucket. The upload itself was never guarded.

## Fix
- Add a `createContext` that derives the caller's role from the **Better Auth server session** (`auth.api.getSession`), never from client input — the same invariant `lib/authGuard.ts` enforces.
- Reject non-admins in the bucket's `beforeUpload` **and** `beforeDelete` hooks, before any signed URL is issued. Both are gated: the forms only call `.upload(...)` today, but the same handler also exposes `.delete(...)`, so leaving delete open would be the same hole by another name.
- `createContext` resolves the role **leniently (no throw)** on purpose: `<EdgeStoreProvider>` is mounted in `app/[locale]/layout.tsx` (every public page), and its client init request flows through this same handler. Throwing would break the provider — and every public page — for anonymous visitors. The per-bucket hooks do the rejecting.

## Verification
- **Static:** confirmed the change type-checks against the real `@edgestore/server@0.1.6` / `@edgestore/shared@0.1.6` type defs (`CreateContextOptions = { req: NextRequest }`; `createContext` required once the context is non-empty; `beforeUpload`/`beforeDelete` take `{ ctx }` → `MaybePromise<boolean>`; the `Context` shape satisfies `AnyContext`).
- **Runtime: NOT yet exercised.** A live admin-vs-anonymous upload needs an env with EdgeStore creds + a reachable Mongo, which the authoring workspace lacks. CI here is docs-path-only, so it does not validate this at runtime. **Reviewer/deployer should confirm the acceptance criteria below against a real environment before relying on it.**

## Acceptance
- [ ] Unauthenticated / non-admin upload to the edgestore route is rejected.
- [ ] Admin dashboard image uploads still succeed.

## Follow-up (separate issue, not this PR)
Relocating `<EdgeStoreProvider>` from the root locale layout to the dashboard layout is a **client-side cleanup**, not part of this security boundary, and is tracked separately.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)