### PR TITLE
fix(i18n): narrow LangSwitch locale to the locales union (unblocks production build)

### DIFF
--- a/components/LangSwitch.tsx
+++ b/components/LangSwitch.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useRouter, usePathname } from "@/navigation";
+import { locales } from "@/config";
 import { useState, useTransition, type MouseEvent } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -24,7 +25,14 @@ function LangSwitch() {
     // `event.target` is typed as `EventTarget`; the clicked <Button> carries the locale in its
     // `value` attribute, so narrow to HTMLButtonElement to read it (runtime behavior unchanged).
     console.log((event.target as HTMLButtonElement).value);
-    const nextLocale = (event.target as HTMLButtonElement).value;
+    // `event.target.value` is a plain `string`, but since PR #129 switched
+    // @/navigation to createSharedPathnamesNavigation, router.replace()'s `locale`
+    // is typed as the `locales` union ("en" | "tr"). The <Button> `value`s below are
+    // only ever those exact locales, so narrow to that union to satisfy the typed
+    // router — a type-only change, runtime behavior is unchanged. (Fixes #135, the
+    // production build break the #129 navigation retype left behind.)
+    const nextLocale = (event.target as HTMLButtonElement)
+      .value as (typeof locales)[number];
     startTransition(() => {
       router.replace(pathname, { locale: nextLocale });
     });


### PR DESCRIPTION
## Problem
`main`'s **production build has been failing since PR #129** (`104-shared-pathnames-navigation`). `next build`:

```
./components/LangSwitch.tsx:29:34
Type error: Type 'string' is not assignable to type '"tr" | "en" | undefined'.
> 29 |       router.replace(pathname, { locale: nextLocale });
```

Because Vercel won't deploy a red build, **no production deploy has shipped since #129** — so unrelated merged work (including the #125 EdgeStore auth fix, PR #131) is merged but **not live**.

## Root cause
#129 switched `@/navigation` to `createSharedPathnamesNavigation`, which types `router.replace()`'s `locale` as the `locales` union (`"en" | "tr"`). `LangSwitch.tsx` derived `nextLocale` from `event.target.value` (a plain `string`) and passed it straight in; #129 retyped the router but never updated this call site.

## Fix
Narrow `nextLocale` to `(typeof locales)[number]`. The `<Button value={...}>` values are only ever the configured locales, so this is a **type-only** change — the cast is erased at compile time, runtime is unchanged.

## Verification
- `npm run typecheck` (`tsc --noEmit`): **clean across the whole project** after the fix (before: the single LangSwitch error above). `tsc` reports all project errors, so this confirms no *further* type errors were hiding behind it.
- Runtime unchanged by construction (a TypeScript cast emits no JS).

## Acceptance
- [x] `tsc --noEmit` passes (no LangSwitch error, no further type errors).
- [ ] Language switch still toggles EN/TR at runtime *(type-only change; behavior provably unchanged, worth a spot-check on the redeployed preview)*.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)