### PR TITLE
docs: single-source the modernization phase index (reshaped 0–9) to README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,12 @@ Guidance for Claude Code (and any AI agent) working in this repository. Read thi
 
 **team-random** is a Next.js 14 (App Router) portfolio / agency site: a public marketing site plus an admin-only dashboard for managing works, team members, and a contact inbox. Built May 2024; being modernized to 2026 standards (see **Modernization** below).
 
-- **Framework:** Next.js 14 (App Router), React 18. **TypeScript** (`.ts`/`.tsx`) as of Phase 3 — only the dead trio (`components/Counter.jsx`, `stores/counter-store.js`, `stores/mailStore.js`, deleted in Phase 6) and the `postcss`/`tailwind` configs remain `.js`.
+- **Framework:** Next.js 14 (App Router), React 18. **TypeScript** (`.ts`/`.tsx`) as of Phase 3 — only the dead trio (`components/Counter.jsx`, `stores/counter-store.js`, `stores/mailStore.js`, slated for deletion in a later cleanup phase) and the `postcss`/`tailwind` configs remain `.js`.
 - **Data:** MongoDB via Mongoose (cached connection in `lib/database.ts`). Models in `models/`: `member`, `work` (the legacy `user` Mongoose model was dropped in Phase 1 — Better Auth now owns the `user`/`account` collections).
 - **Auth:** Better Auth (email/password over MongoDB; existing bcrypt hashes preserved from the legacy next-auth data). Role-based (`admin` / `user`) via the admin plugin. **Authorization is derived from the server session** — `lib/authGuard.ts` → `requireAdmin()` and `auth.api.getSession()` (`lib/auth.ts`); never trust a client-supplied role. The dashboard is admin-only, enforced server-side in its layout. (Replaced next-auth v4 in Phase 1 — PR #88.)
 - **Uploads:** EdgeStore (`lib/edgestore.ts`). **Email:** Gmail SMTP for the contact form + IMAP for the inbox, via `nodemailer` / `imapflow`.
-- **i18n:** next-intl (`config.ts`, `navigation.ts`, `i18n.ts`, `messages/en.json` + `messages/tr.json`) — most strings are still hardcoded (addressed in Phase 6).
-- **State:** zustand + jotai (to be consolidated in Phase 6). **UI:** Tailwind + shadcn/ui (`components/ui/`) + Radix + Framer Motion. **Gotcha:** keep Tailwind's `content` globs in `tailwind.config.js` at `.{js,ts,jsx,tsx,mdx}` — the Phase 3 TS migration left them at `.{js,jsx}`, so Tailwind scanned none of the `.tsx` sources, generated no utilities, and the whole site rendered as unstyled HTML on a bare background (regression fixed in PR #120).
+- **i18n:** next-intl (`config.ts`, `navigation.ts`, `i18n.ts`, `messages/en.json` + `messages/tr.json`) — most strings are still hardcoded (addressed in the i18n phase).
+- **State:** zustand + jotai (to be consolidated in a later phase). **UI:** Tailwind + shadcn/ui (`components/ui/`) + Radix + Framer Motion. **Gotcha:** keep Tailwind's `content` globs in `tailwind.config.js` at `.{js,ts,jsx,tsx,mdx}` — the Phase 3 TS migration left them at `.{js,jsx}`, so Tailwind scanned none of the `.tsx` sources, generated no utilities, and the whole site rendered as unstyled HTML on a bare background (regression fixed in PR #120).
 
 ### Layout
 - `actions/` — server actions (`"use server"`): `memberAction`, `workAction`, `userActions`, `emailAction`.
@@ -25,7 +25,7 @@ Guidance for Claude Code (and any AI agent) working in this repository. Read thi
 ### Commands
 - `npm run dev` — dev server (needs env vars + a reachable MongoDB).
 - `npm run build` — production build (to fully complete it also needs EdgeStore keys + a DB).
-- `npm run lint` — ESLint. NOTE: the config is currently broken (`Failed to load config "next/babel"`); Phase 5 replaces it with flat config.
+- `npm run lint` — ESLint. NOTE: the config is currently broken (`Failed to load config "next/babel"`); the tooling/tests/CI phase replaces it with flat config.
 
 ### Environment (nothing committed; `.env*.local` is gitignored)
 All env vars are validated once at boot in **`lib/env.ts`** (Zod, fail-fast, server-only) — import `env` from there, never read `process.env` directly. **Required:** `MONGO_URI`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `APP_EMAIL`, `APP_PASSWORD`, `EDGE_STORE_ACCESS_KEY`, `EDGE_STORE_SECRET_KEY`. **Optional (defaults in `lib/env.ts`):** `NEXT_PUBLIC_API_BASE_URL` (`http://localhost:3000`), `IMAP_HOST` (`imap.gmail.com`), `IMAP_PORT` (`993`), `SALT_ROUNDS` (`10`).

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -3,7 +3,15 @@
 Per-phase documentation for the **team-random** modernization to 2026 best practices
 (tracking epic [#81](https://github.com/KBerkeYilmaz/team_random/issues/81)). One folder per phase.
 
-**Full plan:** [plan.md](plan.md) — the complete 8-phase modernization plan (context, sequencing rationale, per-phase scope, effort, and critical files).
+**Full plan:** [plan.md](plan.md) — the modernization plan (context, sequencing rationale, per-phase scope, effort, and critical files).
+
+> **This table is the canonical phase index + status (Phases 0–9).** The roadmap was
+> **reshaped 2026-07-09** (epic [#81](https://github.com/KBerkeYilmaz/team_random/issues/81)):
+> tests/CI pulled ahead of the Next 16 bump, a Prisma-on-Postgres + tRPC data layer
+> un-deferred, and the old "i18n + frontend polish" phase split in two. `plan.md`'s
+> **detailed per-phase sections still use the pre-reshape 0–7 numbering** — renumbering
+> them to match this table is tracked in
+> [#142](https://github.com/KBerkeYilmaz/team_random/issues/142).
 
 | Phase | Doc | Status |
 |---|---|---|
@@ -11,10 +19,12 @@ Per-phase documentation for the **team-random** modernization to 2026 best pract
 | 1 — Better Auth (replaces next-auth v4) | [phase1/better-auth.md](phase1/better-auth.md) | ✅ Shipped — PR #88 |
 | 2 — Database & env hardening | [phase2/db-env-hardening.md](phase2/db-env-hardening.md) | ✅ Shipped — PR #97 |
 | 3 — Full TypeScript migration | [phase3/typescript-migration.md](phase3/typescript-migration.md) | ✅ Shipped — PR #103 |
-| 4 — Next 16 / React 19 | _tbd_ | Not started |
-| 5 — Tooling, tests, CI | _tbd_ | Not started |
-| 6 — i18n completion + frontend polish | _tbd_ | Not started |
-| 7 — Migrate npm → pnpm (final step) | _tbd_ | Not started |
+| 4 — Tooling, tests, CI | _tbd_ | ⏳ Not started — **next** |
+| 5 — Next 16 / React 19 | _tbd_ | Not started |
+| 6 — Data layer: Prisma on Postgres + tRPC | _tbd_ | Not started |
+| 7 — i18n completion | _tbd_ | Not started |
+| 8 — Frontend polish | _tbd_ | Not started |
+| 9 — Migrate npm → pnpm (final step) | _tbd_ | Not started |
 
 Each phase ships as its own PR off `main` and closes its phase issue. See the full plan at
 [plan.md](plan.md).

--- a/docs/migration/plan.md
+++ b/docs/migration/plan.md
@@ -1,5 +1,13 @@
 # Modernization Plan — Team Random (Next.js Portfolio/Agency Site)
 
+> ⚠️ **Sequencing reshaped 2026-07-09 (epic #81) — the per-phase sections below still use
+> the pre-reshape 0–7 numbering.** The canonical phase index + current status is
+> [`docs/migration/README.md`](README.md) (Phases 0–9). Renumbering these detailed sections
+> to 0–9 — tooling/CI ahead of the Next 16 bump, un-defer the Prisma-on-Postgres + tRPC
+> data layer, split i18n / frontend polish, pnpm → Phase 9 — is tracked in
+> [#142](https://github.com/KBerkeYilmaz/team_random/issues/142). Until then read the phase
+> **numbers** below as historical; the **scope** of each is still accurate.
+
 ## Context
 
 `team-random` is a Next.js 14 App Router portfolio/agency site (public site + admin dashboard) built in **May 2024, pre-AI-tooling**, and dormant since. It's all JavaScript (`.jsx`), on MongoDB/Mongoose, next-auth v4, EdgeStore, and IMAP/SMTP email. The user wants to modernize it to 2026 best practices and make it a showcase-quality project.


### PR DESCRIPTION
## What & why
Epic #81 was reshaped 2026-07-09 to Phases **0–9**, but the committed migration docs still showed the pre-reshape **0–7** — so a fresh agent reading `docs/migration/` got the wrong "what's next". Drift surfaced by the new `/doc-sync` skill; this is its first real job.

**Adjudication (per the skill):** the reshape is the *latest recorded decision* (intent authority) and PRs #83/#88/#97/#103 confirm 0–3 shipped (git authority) → `README.md` / `plan.md` (still 0–7) were the stale copies. Fix = **single-source the phase index to `docs/migration/README.md`** and point everything else at it.

## Changes
- **`docs/migration/README.md`** — rewritten to the 0–9 index/status table (0–3 shipped; **4 = Tooling/tests/CI is next**) + a reshape note. Now the single owner of the phase index.
- **`docs/migration/plan.md`** — reshape banner at the top: its detailed sections still use the pre-reshape 0–7 numbering; canonical index = README; the detailed 0–9 renumber is tracked in **#142**.
- **`CLAUDE.md`** — de-numbered the *forward* phase-prose refs (`Phase 6` → "the i18n phase", etc.) so churny numbers live only in the README owner; shipped Phase 1/3 refs keep their stable numbers.
- **epic #81** — added a pointer marking README as the canonical index (checklist stays for tracking).

## Scope (one concern)
This PR single-sources the **index/status**. The **detailed plan.md section rewrite** (renumber, un-defer Prisma, split i18n/frontend) is **#142** — separate concern, and it carries a flagged judgment call (where state-consolidation/dead-file cleanup lands). Deferring it is deliberate: it's the judgment-heavy rewrite the epic itself deferred, and doc-sync says *surface, don't guess*.

## Verification
- `npm run check:docs` ✓
- Docs-only → `typecheck-and-build` unaffected.

## doc-sync summary
```
- docs/migration/README.md .... updated — 0–9 index/status (canonical owner)
- docs/migration/plan.md ...... updated — reshape banner → README; detail renumber = #142
- CLAUDE.md (root) ............ updated — de-numbered 4 forward phase refs
- epic #81 ................... updated — pointer: README is canonical index
- issue #141 ................. acceptance criteria met
- issue #142 ................. opened for the deferred plan.md detail rewrite
- npm run check:docs .......... ✓ passing
- SKIPPED: plan.md detailed sections — deferred to #142 (judgment-heavy; not guessed)
```

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)
