### PR TITLE
docs(env): add .env.example documenting required environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,52 @@
+# .env.example — template for the environment variables this app requires.
+#
+# Copy to `.env.local` (gitignored) and fill in the blanks, then mirror the same
+# values into the Vercel project settings. This file is the fill-in checklist for
+# repopulating a deploy — it lists every variable validated by `lib/env.ts`, the
+# single source of truth. Keep the two in sync: if you add/remove/rename a var in
+# `lib/env.ts`, update this file in the same change.
+#
+# SECRETS ARE LEFT BLANK on purpose — never commit real credentials. Non-secret
+# config is pinned to its concrete default so a fresh checkout works out of the box.
+
+# ── Required (7) — the app fails to boot if any of these is missing ──────────────
+
+# MongoDB connection string. Must include the database path segment
+# `team_random_webApp`, or Mongo silently reads the empty `test` database.
+# e.g. mongodb+srv://<user>:<pass>@<cluster>/team_random_webApp?retryWrites=true&w=majority
+MONGO_URI=
+
+# Better Auth session-signing secret. Generate a strong random value,
+# e.g. `openssl rand -base64 32`.
+BETTER_AUTH_SECRET=
+
+# Public base URL Better Auth issues cookies/callbacks against.
+# Local dev: http://localhost:3000 — production: the deployed origin.
+BETTER_AUTH_URL=http://localhost:3000
+
+# Gmail account + App Password for the contact form (SMTP send) and dashboard
+# inbox (IMAP read) — the contact/inbox loop is a core part of what this app does,
+# hence these live here. They are OPTIONAL (blank is tolerated at boot; see the
+# APP_EMAIL / APP_PASSWORD note in lib/env.ts) because we no longer hold the Gmail
+# App Password: while unset, send + inbox read are inert with no other behaviour
+# change. Slated for removal — issue #116 swaps this Gmail integration for Resend
+# + a Prisma-backed inbox, dropping both vars (and IMAP_HOST/IMAP_PORT below).
+APP_EMAIL=
+APP_PASSWORD=
+
+# EdgeStore upload credentials (dashboard.edgestore.dev).
+EDGE_STORE_ACCESS_KEY=
+EDGE_STORE_SECRET_KEY=
+
+# ── Optional (4) — sensible defaults in lib/env.ts; override only if needed ──────
+
+# Base URL the contact helper POSTs to. Defaults to http://localhost:3000.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
+
+# IMAP server for the dashboard inbox. Defaults to Gmail's. Removed alongside
+# APP_EMAIL / APP_PASSWORD once issue #116 lands.
+IMAP_HOST=imap.gmail.com
+IMAP_PORT=993
+
+# bcrypt cost factor for password hashing. Defaults to 10.
+SALT_ROUNDS=10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Guidance for Claude Code (and any AI agent) working in this repository. Read thi
 - `npm run lint` — ESLint. NOTE: the config is currently broken (`Failed to load config "next/babel"`); the tooling/tests/CI phase replaces it with flat config.
 
 ### Environment (nothing committed; `.env*.local` is gitignored)
-All env vars are validated once at boot in **`lib/env.ts`** (Zod, fail-fast, server-only) — import `env` from there, never read `process.env` directly. **Required:** `MONGO_URI`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `APP_EMAIL`, `APP_PASSWORD`, `EDGE_STORE_ACCESS_KEY`, `EDGE_STORE_SECRET_KEY`. **Optional (defaults in `lib/env.ts`):** `NEXT_PUBLIC_API_BASE_URL` (`http://localhost:3000`), `IMAP_HOST` (`imap.gmail.com`), `IMAP_PORT` (`993`), `SALT_ROUNDS` (`10`).
+All env vars are validated once at boot in **`lib/env.ts`** (Zod, fail-fast, server-only) — import `env` from there, never read `process.env` directly. **Required:** `MONGO_URI`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `APP_EMAIL`, `APP_PASSWORD`, `EDGE_STORE_ACCESS_KEY`, `EDGE_STORE_SECRET_KEY`. **Optional (defaults in `lib/env.ts`):** `NEXT_PUBLIC_API_BASE_URL` (`http://localhost:3000`), `IMAP_HOST` (`imap.gmail.com`), `IMAP_PORT` (`993`), `SALT_ROUNDS` (`10`). The committed **`.env.example`** template enumerates all of these (secrets blank, non-secret config pinned) — copy it to `.env.local` and fill in the blanks, then mirror into Vercel.
 
 ## Modernization (the current effort)
 


### PR DESCRIPTION
## What & why

There was no committed env template, which made the recent "the Vercel env vars are gone" incident harder to reason about — nothing in the repo enumerated the variables a deploy needs.

This adds a root `.env.example` that:
- **Enumerates every variable** validated by `lib/env.ts` — the 7 "required" (`MONGO_URI`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `APP_EMAIL`, `APP_PASSWORD`, `EDGE_STORE_ACCESS_KEY`, `EDGE_STORE_SECRET_KEY`) plus the 4 optional-with-defaults (`NEXT_PUBLIC_API_BASE_URL`, `IMAP_HOST`, `IMAP_PORT`, `SALT_ROUNDS`).
- **Leaves secrets blank** — never commits real values.
- **Pins the non-secret config** to its concrete default: IMAP (`IMAP_HOST=imap.gmail.com`, `IMAP_PORT=993`), the local URLs, and `SALT_ROUNDS=10`.

Serves as the fill-in checklist for repopulating `.env.local` and the Vercel project.

The `.env.example` header notes it must stay in sync with `lib/env.ts` (the single source of truth), and the root `CLAUDE.md` Environment section now points at the template.

## Verification
- `git check-ignore .env.example` → not ignored (the `.env*.local` glob does not match), so the template is committed while real `.env.local` stays gitignored.
- `npm run check:docs` → ✓ passing.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)