### PR TITLE
fix(middleware): drop non-existent /contact from publicPages

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -12,7 +12,7 @@ import { getSessionCookie } from "better-auth/cookies";
 import { NextResponse, type NextRequest } from "next/server";
 
 const locales = ["en", "tr"];
-const publicPages = ["/", "/login", "/works", "/contact", "/about"];
+const publicPages = ["/", "/login", "/works", "/about"];
 
 const intlMiddleware = createIntlMiddleware({
   locales,


### PR DESCRIPTION
## What

`middleware.ts` listed `/contact` in `publicPages`, but there is no `/contact` route — the contact form is the `#cta` section of the home page. The public routes are `/`, `/login`, `/works`, `/about` (+ the gated dashboard). The entry was dead: `/contact` never resolved to a page, so treating it as "public" had no effect.

Removes the dead entry.

## Verification

Reasoned + empirically checked the `publicPathnameRegex` after the change: every real public route and its locale variant (`/`, `/en`, `/tr`, `/login`, `/en/login`, `/works`, `/tr/works`, `/about`, `/en/about`) still matches as PUBLIC; dashboard routes stay gated. `/contact` is now gated instead of public, but since it has no page it 404s either way — no real route's auth/routing behaviour changed.

Note: this was scoped in the issue as foldable into Phase 5 (the `middleware.ts` → `proxy.ts` rename); shipping it now as a standalone one-line cleanup per request. No doc references the `publicPages` list, so no doc updates were needed (the "contact form"/"contact inbox" mentions in docs refer to the `#cta` form, which is unchanged).

## Acceptance
- [x] `/contact` removed; auth/routing behaviour unchanged.

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)