### PR TITLE
fix(auth): align client/server password rules, single-source schema (#126)

### DIFF
--- a/actions/CLAUDE.md
+++ b/actions/CLAUDE.md
@@ -31,10 +31,12 @@ Match this; don't invent a per-action shape.
 - `memberSchema` / `updateMemberSchema` / `workSchema` live in `actions/schemas.ts`
   and are **shared** with the forms via `z.infer` — edit the schema once, both sides
   follow.
-- **Exception:** `userActions.ts` defines its Zod schemas **inline per function**, and
-  the user/contact/login forms carry their own local schemas — so user-account
-  validation is duplicated and has already drifted (client vs server password length).
-  Do not assume "all forms share schemas."
+- **Partial exception:** `updateUserPassword` now shares `updatePasswordSchema` from
+  `actions/schemas.ts` with `EditUserPasswordForm` (issue #126 — this closed the old
+  client `min(3)` vs server `min(8)` drift). The rest of `userActions.ts` still defines
+  its Zod schemas **inline per function**, and the user/contact/login forms carry their
+  own local schemas — so most user-account validation is still duplicated. Do not assume
+  "all forms share schemas."
 
 ## Data access & logging
 Reads go through the Mongoose models in `models/` via `connectDB()`

--- a/actions/schemas.ts
+++ b/actions/schemas.ts
@@ -39,3 +39,31 @@ export const workSchema = z.object({
   workImages: z.array(z.string().url()).optional(),
 });
 export type WorkInput = z.infer<typeof workSchema>;
+
+// Password change for the current user's own account. Single-sourced here (issue
+// #126) so the client form (zodResolver) and the server action (safeParse) share
+// ONE definition and can never drift again: the two used to disagree — the client
+// validated newPassword with min(3) while the server enforced min(8), so a 3–7
+// character password passed client validation and then failed server-side,
+// surfacing as a generic error instead of an inline field message.
+//
+// All three fields require at least 8 characters (Better Auth's server-side
+// minimum for a stored password is 8, so the current password is necessarily 8+
+// too), and the confirmation must match the new password.
+export const updatePasswordSchema = z
+  .object({
+    currentPassword: z
+      .string()
+      .min(8, "Current password must be at least 8 characters."),
+    newPassword: z
+      .string()
+      .min(8, "New password must be at least 8 characters."),
+    passwordConfirmation: z
+      .string()
+      .min(8, "Password confirmation must be at least 8 characters."),
+  })
+  .refine((data) => data.newPassword === data.passwordConfirmation, {
+    message: "Passwords don't match",
+    path: ["passwordConfirmation"], // attach the mismatch error to the confirm field
+  });
+export type UpdatePasswordInput = z.infer<typeof updatePasswordSchema>;

--- a/actions/userActions.ts
+++ b/actions/userActions.ts
@@ -4,14 +4,10 @@ import { headers } from "next/headers";
 import { requireAdmin } from "@/lib/authGuard";
 import { z } from "zod";
 import type { ActionState } from "@/actions/types";
+import { updatePasswordSchema, type UpdatePasswordInput } from "@/actions/schemas";
 
 // The current user's own-account edit payloads (the values each form submits).
 type UpdateUserInput = { name: string; email: string };
-type UpdateUserPasswordInput = {
-  currentPassword: string;
-  newPassword: string;
-  passwordConfirmation: string;
-};
 
 // AUDIT #83 (issue #82): every action below is gated by requireAdmin(), which
 // derives the admin role from the server session. Previously each took a `role`
@@ -93,25 +89,12 @@ export const updateUserImage = async (
 };
 
 export const updateUserPassword = async (
-  formData: UpdateUserPasswordInput,
+  formData: UpdatePasswordInput,
   id: string,
 ): Promise<ActionState> => {
-  const userSchema = z
-    .object({
-      currentPassword: z.string().min(3),
-      // Better Auth enforces a minimum length server-side (default 8); align the
-      // client validation so users get a clear message instead of an API error.
-      newPassword: z
-        .string()
-        .min(8, "New password must be at least 8 characters."),
-      passwordConfirmation: z.string().min(8),
-    })
-    .refine((data) => data.newPassword === data.passwordConfirmation, {
-      message: "Passwords don't match",
-      path: ["passwordConfirmation"], // path of error
-    });
-
-  const validatedFields = userSchema.safeParse({
+  // Shared with EditUserPasswordForm via actions/schemas.ts so client and server
+  // password rules can't drift (issue #126).
+  const validatedFields = updatePasswordSchema.safeParse({
     currentPassword: formData.currentPassword,
     newPassword: formData.newPassword,
     passwordConfirmation: formData.passwordConfirmation,

--- a/components/forms/CLAUDE.md
+++ b/components/forms/CLAUDE.md
@@ -17,10 +17,11 @@ and a `Loader2` spinner while submitting.
 
 ## Gotchas
 - **Schema source is split:** member/work forms import shared schemas from
-  `actions/schemas.ts` (`z.infer`); user/contact/login forms use **local inline**
-  schemas. Before changing validation, check which regime the form is in.
-  - Known drift: `EditUserPasswordForm`'s client `min(3)` vs the server's `min(8)` —
-    keep client and server rules aligned.
+  `actions/schemas.ts` (`z.infer`); the remaining user/contact/login forms use **local
+  inline** schemas. Before changing validation, check which regime the form is in.
+  - `EditUserPasswordForm` was moved into the shared regime: it now imports
+    `updatePasswordSchema` from `actions/schemas.ts` (issue #126), closing the old
+    client `min(3)` vs server `min(8)` drift. All three password fields require `min(8)`.
 - The client `role !== "admin"` bail-out is a **UX hint only** — the action's
   `requireAdmin()` is the real boundary.
 - `ContactForm`'s `if (result.error)` branch is effectively dead (`sendMail` never

--- a/components/forms/EditUserPasswordForm.tsx
+++ b/components/forms/EditUserPasswordForm.tsx
@@ -17,16 +17,10 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-const formSchema = z
-  .object({
-    currentPassword: z.string().min(3),
-    newPassword: z.string().min(3),
-    passwordConfirmation: z.string().min(3),
-  })
-  .refine((data) => data.newPassword === data.passwordConfirmation, {
-    message: "Passwords don't match",
-    path: ["passwordConfirmation"], // path of error
-  });
+// Single-sourced with the server action (actions/schemas.ts) so client and server
+// password rules stay in lockstep — issue #126. Both used to disagree (client
+// min(3) vs server min(8)).
+import { updatePasswordSchema } from "@/actions/schemas";
 
 import { useToast } from "../ui/use-toast";
 import { updateUserPassword } from "@/actions/userActions";
@@ -40,15 +34,15 @@ export const EditUserPasswordForm = ({
   const { toast } = useToast();
   // console.log(user);
 
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
+  const form = useForm<z.infer<typeof updatePasswordSchema>>({
+    resolver: zodResolver(updatePasswordSchema),
     defaultValues: {
       currentPassword: "",
       newPassword: "",
       passwordConfirmation: "",
     },
   });
-  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+  const onSubmit = async (values: z.infer<typeof updatePasswordSchema>) => {
     console.log(values);
     // AUDIT #83: UX hint only, NOT the security boundary — real authorization is
     // enforced server-side in the action (requireAdmin). Kept for a friendly toast.


### PR DESCRIPTION
## What & why

`EditUserPasswordForm` validated `newPassword` with a client-side `z.string().min(3)`, but the `updateUserPassword` server action enforced `min(8)`. A 3–7 character password passed client validation, then failed server-side and surfaced as a **generic error** instead of an inline field message (issue #126).

## Change

- **Single-source the schema.** Added `updatePasswordSchema` to `actions/schemas.ts` — the existing single-source home for member/work validation — and wired both sides to it:
  - `actions/userActions.ts` → `updateUserPassword` `safeParse`s it (replacing its inline schema + the local `UpdateUserPasswordInput` type, now `z.infer`).
  - `components/forms/EditUserPasswordForm.tsx` → `zodResolver(updatePasswordSchema)` (replacing its local `formSchema`).
- **All three password fields now require `min(8)`** (per the request that both passwords require a minimum of 8 characters). Better Auth's server-side stored-password minimum is 8, so the current password is necessarily 8+ too.
- Client and server can no longer drift — one definition feeds both.

## Docs

- `actions/CLAUDE.md` and `components/forms/CLAUDE.md` updated: `EditUserPasswordForm` moved into the shared-schema regime; the documented `min(3)` vs `min(8)` drift is closed.

## Acceptance (from #126)
- [x] Client and server agree on password rules — one shared schema.
- [x] A short password shows an inline field error, not a generic server error — client `zodResolver` now rejects `< 8` with the field message.

## Verification
- `npm run typecheck` → clean.
- `npm run check:docs` → ✓ all 80 paths resolve.
- `/doc-sync` semantic pass run before opening.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)