### PR TITLE
docs: correct stale sendMail/ContactForm error-branch note (post-#127)

### DIFF
--- a/components/forms/CLAUDE.md
+++ b/components/forms/CLAUDE.md
@@ -27,5 +27,6 @@ and a `Loader2` spinner while submitting.
     copy-pasted "Member name…").
 - The client `role !== "admin"` bail-out is a **UX hint only** — the action's
   `requireAdmin()` is the real boundary.
-- `ContactForm`'s `if (result.error)` branch is effectively dead (`sendMail` never
-  returns `{ error }`), so a failed send still shows a non-destructive toast.
+- `ContactForm`'s `if (result.error)` branch is **live**: `sendMail` honours `response.ok`
+  (issue #127) and returns `{ error }` on a failed send, so a failure shows the
+  **destructive** toast (a 503 surfaces an `"email-not-configured"` hint).

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -25,8 +25,10 @@ runtime.)
 - `edgestore.ts` — `"use client"` EdgeStore provider/hook (`EdgeStoreProvider`,
   `useEdgeStore`).
 - `sendMail.ts` — `sendEmail()`, a plain `fetch` wrapper POSTing to the contact API.
-  **Not** a server action. Gotcha: it returns `{ message }` on both success *and*
-  failure (it ignores `response.ok`), so a caller's `.error` branch is effectively dead.
+  **Not** a server action. It **honours `response.ok`** (issue #127): a failed send returns
+  `{ error, message }` (a 503 → an `"email-not-configured"` hint; other non-ok responses /
+  a network throw → a generic `"send-failed"`), while success returns `{ message }`. So a
+  caller's `.error` branch is **live** — `ContactForm` shows a destructive toast on failure.
 - `utils.ts` — `cn()` (clsx + tailwind-merge), the shadcn helper.
 
 There is no logger module — logging is bare `console.error`. Better Auth and Mongoose


### PR DESCRIPTION
Closes #155. Docs-only follow-up surfaced during Phase 4b (PR #154).

Two module `CLAUDE.md` files still described `lib/sendMail.ts`'s **pre-#127** behaviour — that it ignores `response.ok`, never returns `{ error }`, so `ContactForm`'s error branch is dead. Since #127, `sendEmail()` **honours `response.ok`** and returns `{ error, message }` on a failed send (503 → an `"email-not-configured"` hint; other non-ok / network throw → a generic `"send-failed"`), so `ContactForm`'s `if (result.error)` branch is **live** and shows the destructive toast.

- `lib/CLAUDE.md` — sendMail bullet rewritten to the current honour-`response.ok` behaviour.
- `components/forms/CLAUDE.md` — the "branch is effectively dead" gotcha flipped to "live".

No code change. `npm run check:docs` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)