### PR TITLE
test(harness): auto-derive Vitest path aliases from tsconfig paths

### DIFF
--- a/docs/migration/phase4/tooling-tests-ci.md
+++ b/docs/migration/phase4/tooling-tests-ci.md
@@ -175,8 +175,10 @@ is low-ROI and largely redundant with the schema tests (see Flags).
 
 ### The harness (`vitest.config.ts` / `vitest.setup.ts`)
 
-- **`@/*` alias via Vitest's built-in `resolve.alias`** (a precise `^@/` regex) — **not** the
-  `vite-tsconfig-paths` plugin the plan sketched (see the load-bearing deviation below).
+- **Path aliases via Vitest's built-in `resolve.alias`, derived from tsconfig `paths`** (each
+  mapping → a precise `^prefix` regex) — **not** the `vite-tsconfig-paths` plugin the plan sketched
+  (see the load-bearing deviation below). _(4b shipped this as a single hard-coded `@/` alias;
+  refined in #160 to read tsconfig at config-load so the two auto-sync.)_
 - **`esbuild: { jsx: "automatic" }`** — required because tsconfig is `jsx: "preserve"` (Next's
   SWC/Babel transforms JSX at build time); without it esbuild would emit un-executable JSX.
 - **`test.environment: "node"`** (the fast default); the single RTL file opts into jsdom via a
@@ -223,6 +225,8 @@ it ships inside 4b (user-approved, not unrelated churn):
    `tsc --noEmit`**. Resolving `@/` with Vitest's built-in alias (a precise `^@/` regex that never
    clobbers scoped `@testing-library/*` packages) needs no external plugin, no second vite, and no
    version pinning — net **two fewer dev deps** than the plan (`vite`, `vite-tsconfig-paths`).
+   _(Follow-up #160 keeps the plugin's auto-sync benefit by deriving the aliases from tsconfig
+   `paths` at config-load via the TypeScript compiler API — still no new dependency.)_
 2. **One user-visible behaviour change.** `EditUserForm`'s name-too-short message becomes the
    canonical **"User name must be at least 3 characters."** (was a copy-pasted "Member name…").
    Safe: `EditUserForm` reads only `result.error`, never the field-level `errors` map, so

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,32 +1,35 @@
 // vitest.config.ts
-// Test-runner configuration for the Phase 4b unit-test suite (issue #153 — the
-// first automated tests in this repo). Kept intentionally minimal: it wires up
-// only what a Next 14 + TypeScript project needs before Vitest can run, and
-// nothing else.
+// Test-runner configuration for the Vitest suite (first added in Phase 4b,
+// issue #153). Kept intentionally minimal: it wires up only what a Next 14 +
+// TypeScript project needs before Vitest can run, and nothing else.
 //
 // Why each option is here (all load-bearing — do not drop one without
 // re-checking what breaks):
 //
-//   resolve.alias  →  the `@/*` path mapping
+//   resolve.alias  →  the tsconfig `paths` mapping(s), derived automatically
 //     Vitest/Vite do not read tsconfig's `paths` on their own, so tests (and the
 //     modules they import) would fail to resolve `@/lib/...`, `@/actions/...`,
-//     etc. We mirror tsconfig's `@/* -> ./*` mapping here.
+//     etc. Rather than hand-copy the `@/* -> ./*` mapping here (which would then
+//     silently drift if someone adds an alias to tsconfig), we READ tsconfig's
+//     `compilerOptions.paths` and translate each mapping into a Vite alias — see
+//     `aliasesFromTsconfigPaths()` below. Add a path mapping to tsconfig.json and
+//     the tests pick it up with no edit here.
 //
-//     A precise `^@/` **regex** (not a bare "@" string alias) is deliberate: it
-//     rewrites only specifiers that begin with `@/…` and never touches scoped
-//     npm packages such as `@testing-library/react` or `@hookform/resolvers`
-//     (the character after their `@` is a letter, not `/`, so the regex can't
-//     match them). A naive string alias of "@" would clobber those and break the
-//     test imports.
+//     Each mapping becomes a precise `^<prefix>` **regex** (not a bare string
+//     alias): `@/*` → `/^@\/(.*)$/`, which rewrites only specifiers beginning
+//     `@/…` and never touches scoped npm packages like `@testing-library/react`
+//     or `@hookform/resolvers` (the char after their `@` is a letter, not `/`).
+//     A naive string alias of "@" would clobber those and break the test imports.
 //
-//     (This replaces the `vite-tsconfig-paths` plugin the plan sketched: that
-//     plugin declares `vite` as a peer dependency, and the only vite that
-//     installs cleanly against this repo's pinned `@types/node@20.12.4` is vite
-//     6, while Vitest 3 bundles vite 7 internally. The resulting split tree
-//     type-checks as two incompatible `Plugin` types and fails `tsc`. Resolving
-//     `@/` with Vitest's own built-in alias needs no external plugin, no second
-//     vite, and no version pinning — see docs/migration/phase4 for the full
-//     rationale.)
+//     Why not the `vite-tsconfig-paths` plugin (which does exactly this)? It
+//     declares `vite` as a peer dependency, and the only vite that installs
+//     cleanly against this repo's pinned `@types/node@20.12.4` is vite 6, while
+//     Vitest 3 bundles vite 7 internally. The resulting split tree type-checks as
+//     two incompatible `Plugin` types and fails `tsc --noEmit` (the pre-commit
+//     hook). Deriving the aliases ourselves gives the same auto-sync with **no**
+//     extra dependency, no second vite, and no version pinning. We parse tsconfig
+//     with the TypeScript compiler API (already a devDependency) so JSONC
+//     comments are handled exactly as `tsc` reads them. See docs/migration/phase4.
 //
 //   esbuild: { jsx: "automatic" }
 //     REQUIRED. tsconfig sets `jsx: "preserve"` because Next's own SWC/Babel
@@ -54,14 +57,38 @@
 //     repo root and is imported once globally.
 import { fileURLToPath } from "node:url";
 
+import ts from "typescript";
 import { defineConfig } from "vitest/config";
 
-// Absolute path to the repo root (trailing slash), used by the `@/…` alias.
+// Absolute path to the repo root (trailing slash) — the base each alias target
+// resolves against.
 const root = fileURLToPath(new URL(".", import.meta.url));
+
+// Translate tsconfig's `compilerOptions.paths` into Vite `resolve.alias` entries,
+// so the two stay in sync automatically. Reads tsconfig via the TypeScript API
+// (comment-tolerant, same as `tsc`). Handles the wildcard form the repo uses
+// (`"@/*": ["./*"]`); a non-wildcard exact mapping, if ever added, would need a
+// small tweak here (and would fail loudly at import, never silently).
+function aliasesFromTsconfigPaths() {
+  const tsconfigPath = fileURLToPath(
+    new URL("./tsconfig.json", import.meta.url),
+  );
+  const { config } = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+  const paths: Record<string, string[]> = config?.compilerOptions?.paths ?? {};
+
+  return Object.entries(paths).map(([pattern, [target]]) => {
+    // "@/*"  → prefix "@/"  → find /^@\/(.*)$/   (the char after "@" must be "/")
+    const prefix = pattern.slice(0, pattern.indexOf("*"));
+    const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // "./*"  → strip leading "./", anchor to repo root, swap the wildcard for $1
+    const replacement = root + target.replace(/^\.\//, "").replace(/\*$/, "$1");
+    return { find: new RegExp(`^${escaped}(.*)$`), replacement };
+  });
+}
 
 export default defineConfig({
   resolve: {
-    alias: [{ find: /^@\/(.*)$/, replacement: `${root}$1` }],
+    alias: aliasesFromTsconfigPaths(),
   },
   esbuild: { jsx: "automatic" },
   test: {


### PR DESCRIPTION
Closes #160. Follow-up to Phase 4b (PR #154) — a maintainability refinement to the test harness.

## Problem
4b's `vitest.config.ts` hard-coded the single `@/*` alias — a manual copy of tsconfig's `paths`. If someone adds an alias to `tsconfig.json`, tests silently wouldn't pick it up until this file was hand-edited too.

## Change
`vitest.config.ts` now **derives** its `resolve.alias` entries from `tsconfig.json`'s `compilerOptions.paths` at config-load time (parsed via the TypeScript compiler API — already a devDependency, so JSONC comments are handled). One ~10-line helper; the alias line swaps from a literal to `aliasesFromTsconfigPaths()`. Same precise `^prefix` regex per mapping, so scoped packages like `@testing-library/*` are never clobbered.

This restores the auto-sync that `vite-tsconfig-paths` would give — **without** that plugin, whose `vite` peer dep forces a second vite major against the pinned `@types/node@20.12.4` and breaks `tsc` (the reason 4b avoided it). **No new dependency.**

## Verification
- **Auto-sync proven:** added `@testalias/* → ./lib/*` to tsconfig only, a throwaway test imported via it and resolved, then reverted — zero edit to `vitest.config.ts`.
- `tsc` clean · `lint` clean · `format` clean · **23/23 tests** green · `check:docs` ✓.

## Caveat
Handles the **wildcard** `paths` form (the only kind this repo uses). A future *exact* (non-wildcard) mapping would need a one-line tweak — and would fail loudly at import, never silently. Noted in the config comment.

Also updates the 4b migration doc's harness + deviation notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)